### PR TITLE
完成 TODO: 使用 `Makefile` 替代 `build.sh`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+OWNER           := hitokoto
+BIN_NAME        := worker
+PROJECT_NAME    := notification_worker
+GIT_COMMIT      := $(shell git rev-parse HEAD)
+GIT_DIRTY       :=
+BUILD_TAGS      :=
+VERSION         := $(shell grep "Version" version.go | awk '{print $$4}' | sed 's/\"//g')
+BUILDBOX_BRANCH := $(shell echo $$BUILDBOX_BRANCH)
+.PHONY: build
+
+ifneq ($(shell git status --porcelain) , "")
+    GIT_DIRTY=+CHANGES
+endif
+
+# building the master branch on ci
+ifeq ($(BUILDBOX_BRANCH) , "master")
+    BUILD_TAGS :=-tags release
+endif
+
+# 构建二进制文件
+define build
+go build -a \
+   	-ldflags "-X main.GitCommit=$(GIT_COMMIT)$(GIT_DIRTY)" \
+   	-o ./bin/$(BIN_NAME)_$(VERSION)_$(1)
+endef
+
+build:
+	$(call build,linux_amd64)
+	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(call build,darwin_amd64)
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 $(call build,windows_amd64.exe)
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 $(call build,linux_arm64)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@
 首先克隆本项目到你的工作目录下，然后编辑代码，即可。这里推荐使用 GoLand 编码。
 
 ## 编译
-> TODO: 使用 `Makefile` 替代 `build.sh`
 
-目前只需要执行 `./build.sh` 即可自动编译。（需要 Linux 环境）
+本项目提供两种编译方法：
 
+1. 在项目根目录使用 `make build` 即可自动编译。（支持 linux macos）
+
+2. 只需要执行 ./build.sh 即可自动编译。（需要 Linux 环境）


### PR DESCRIPTION
**涉及文件：**

Makefile README.md

**修改之处：**

对于VERSION变量的获取方式有所修改，因原代码的sed参数无法在 macos 中使用

**说明：**

本 Makefile 实现逻辑和输入输出，与 build.sh 完全一致，包括 BUILDBOX 判断。

本 Makefile 在 macos 10.15.5本地 和 golang官方Linux镜像 下编译成功，测试输出与 build.sh 一致。